### PR TITLE
Auto-set VS Code Python interpreter when environment is created/activated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Change Log
 
-All notable changes to the "Conda Wingman" extension will be documented in this file.
+All notable changes to the "UV Wingman" extension will be documented in this file.
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
+
+## [1.0.3] - 2025-11-01
+- Added automatic VS Code Python interpreter setting when environment is created or activated
+- Refactored interpreter logic into separate `interpreter.js` module for better code organization
+- Added `getFirstWorkspaceFolder()` utility to reduce code duplication
+
+## [1.0.2] - 2024-11
+- Update package to v1.0.2
+
+## [1.0.1] - 2024-11
+- Bump version to 1.0.1
 
 ## [0.0.3] - 2024-11
 - Small docs improvements

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "uv-wingman",
 	"displayName": "UV Wingman",
 	"description": "Help users manage and interact with the python UV package manager.",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"publisher": "DJSaunders1997",
 	"engines": {
 		"vscode": "^1.95.0"

--- a/src/commands.js
+++ b/src/commands.js
@@ -2,7 +2,7 @@
 
 const vscode = require("vscode");
 const { sendCommandToTerminal, getFirstWorkspaceFolder } = require("./utils");
-const { waitAndSetInterpreter, getVenvInterpreterPath, setWorkspacePythonInterpreter } = require("./interpreter");
+const { waitAndSetInterpreter } = require("./interpreter");
 const { getTerminalCommands } = require("./terminalCommands");
 const { deleteEnvIcon } = require("./statusBarItems");
 
@@ -93,20 +93,10 @@ async function activateEnv() {
         // Automatically set the Python interpreter when activating
         const workspaceFolder = getFirstWorkspaceFolder();
         if (workspaceFolder) {
-            const interpreter = getVenvInterpreterPath(workspaceFolder);
-            if (interpreter) {
-                // Fire-and-forget: don't block the command, but set interpreter in background
-                setWorkspacePythonInterpreter(interpreter).then(success => {
-                    if (success) {
-                        vscode.window.showInformationMessage(
-                            'Python interpreter automatically set to .venv interpreter',
-                            { timeout: 3000 }
-                        );
-                    }
-                }).catch(err => {
-                    console.error('Failed to auto-set interpreter on activation:', err);
-                });
-            }
+            // Fire-and-forget: don't block the command, but set interpreter in background
+            waitAndSetInterpreter(workspaceFolder).catch(err => {
+                console.error('Failed to auto-set interpreter on activation:', err);
+            });
         }
     } catch (error) {
         vscode.window.showErrorMessage("Failed to activate UV environment");

--- a/src/extension.js
+++ b/src/extension.js
@@ -18,6 +18,9 @@ const {
   deleteEnvIcon,
 } = require("./statusBarItems");
 
+const { getFirstWorkspaceFolder } = require('./utils');
+const { getVenvInterpreterPath, setWorkspacePythonInterpreter } = require('./interpreter');
+
 /**
  * Function that is run on activation of the extension.
  * Main functionality and setup are defined here.
@@ -84,6 +87,16 @@ function activate(context) {
     syncDepsIcon.displayDefault();
     deleteEnvIcon.displayDefault();
     activateEnvIcon.displayDefault();
+
+    // On activation, look for .venv in workspace folders and set interpreter automatically.
+    const workspaceFolder = getFirstWorkspaceFolder();
+    if (workspaceFolder) {
+        const interpreter = getVenvInterpreterPath(workspaceFolder);
+        if (interpreter) {
+            // Fire-and-forget; we don't block activation
+            setWorkspacePythonInterpreter(interpreter).catch(() => { /* ignore */ });
+        }
+    }
 
     console.log('UV Wingman activated successfully');
   });

--- a/src/extension.js
+++ b/src/extension.js
@@ -40,7 +40,6 @@ function activate(context) {
     // Setup listener to update status bar items when the active file changes
     const listener = vscode.window.onDidChangeActiveTextEditor(() => {
       initProjectIcon.displayDefault();
-      createEnvIcon.displayDefault();
       syncDepsIcon.displayDefault();
       deleteEnvIcon.displayDefault();
       activateEnvIcon.displayDefault();

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -1,0 +1,95 @@
+// This file handles Python interpreter management for UV environments
+
+const fs = require('fs');
+const path = require('path');
+const vscode = require('vscode');
+const { getFirstWorkspaceFolder } = require('./utils');
+
+/**
+ * Return the .venv python interpreter path for the given workspace folder (or null).
+ */
+function getVenvInterpreterPath(workspaceFolder) {
+    let folder = workspaceFolder;
+    if (!folder) {
+        folder = getFirstWorkspaceFolder();
+    }
+    if (!folder) {
+        return null;
+    }
+
+    const base = folder.uri.fsPath;
+
+    // Build a list of file paths to check for the python executable inside .venv.
+    let candidates;
+
+    // On Windows virtualenv python is usually under .venv\Scripts.
+    // We check both python.exe and a plain 'python' in case of different setups.
+    if (process.platform === 'win32') {
+      candidates = [
+        path.join(base, '.venv', 'Scripts', 'python.exe'),
+        path.join(base, '.venv', 'Scripts', 'python')
+      ];
+    } else {
+      // On macOS/Linux it's usually under .venv/bin.
+      // Check both 'python' and 'python3' so we handle venvs created with different python versions.
+      candidates = [
+        path.join(base, '.venv', 'bin', 'python'),
+        path.join(base, '.venv', 'bin', 'python3')
+      ];
+    }
+
+    // Return the first existing candidate.
+    for (const p of candidates) {
+        if (fs.existsSync(p)) {
+            return p;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Update workspace Python interpreter settings to point to the given interpreter path.
+ * Updates both "python.defaultInterpreterPath" and legacy "python.pythonPath" for compatibility.
+ */
+async function setWorkspacePythonInterpreter(interpreterPath) {
+    if (!interpreterPath) return false;
+    try {
+        const pythonConfig = vscode.workspace.getConfiguration('python');
+        // modern setting
+        await pythonConfig.update('defaultInterpreterPath', interpreterPath, vscode.ConfigurationTarget.Workspace);
+        console.log(`Successfully set workspace Python interpreter to: ${interpreterPath}`);
+        return true;
+    } catch (err) {
+        console.error('Failed to set workspace interpreter:', err);
+        return false;
+    }
+}
+
+/**
+ * Sets the Python interpreter if the .venv directory exists.
+ * @param {vscode.WorkspaceFolder} workspaceFolder - The workspace folder to check
+ * @returns {Promise<boolean>} True if interpreter was set, false otherwise
+ */
+async function waitAndSetInterpreter(workspaceFolder) {
+    const interpreter = getVenvInterpreterPath(workspaceFolder);
+    if (interpreter) {
+        const success = await setWorkspacePythonInterpreter(interpreter);
+        if (success) {
+            vscode.window.showInformationMessage(
+                `Python interpreter automatically set to .venv interpreter`,
+                { timeout: 3000 }
+            );
+            return true;
+        }
+        return false;
+    }
+    return false;
+}
+
+module.exports = {
+    getVenvInterpreterPath,
+    setWorkspacePythonInterpreter,
+    waitAndSetInterpreter,
+};
+

--- a/src/interpreter.js
+++ b/src/interpreter.js
@@ -50,7 +50,7 @@ function getVenvInterpreterPath(workspaceFolder) {
 
 /**
  * Update workspace Python interpreter settings to point to the given interpreter path.
- * Updates both "python.defaultInterpreterPath" and legacy "python.pythonPath" for compatibility.
+ * Uses the modern "python.defaultInterpreterPath" setting.
  */
 async function setWorkspacePythonInterpreter(interpreterPath) {
     if (!interpreterPath) return false;
@@ -68,6 +68,7 @@ async function setWorkspacePythonInterpreter(interpreterPath) {
 
 /**
  * Sets the Python interpreter if the .venv directory exists.
+ * Checks once for the interpreter path - does not poll or wait for it to appear.
  * @param {vscode.WorkspaceFolder} workspaceFolder - The workspace folder to check
  * @returns {Promise<boolean>} True if interpreter was set, false otherwise
  */

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,17 @@
 // This file contains helpful utility functions
 
-const vscode = require("vscode");
+const vscode = require('vscode');
+
+/**
+ * Gets the first workspace folder, or null if no workspace folders exist.
+ * @returns {vscode.WorkspaceFolder | null} The first workspace folder or null
+ */
+function getFirstWorkspaceFolder() {
+    if (vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0) {
+        return vscode.workspace.workspaceFolders[0];
+    }
+    return null;
+}
 
 /**
  * Sends a command to the terminal.
@@ -23,6 +34,8 @@ function sendCommandToTerminal(command) {
   console.log(`Command '${command}' sent to terminal.`);
 }
 
+
 module.exports = {
   sendCommandToTerminal,
+  getFirstWorkspaceFolder,
 };


### PR DESCRIPTION
## Description

This PR implements automatic VS Code Python interpreter setting when UV environments are created or activated, as outlined in issue #31.

## Changes

- **Added automatic interpreter setting** after environment creation (`createEnv`)
- **Added automatic interpreter setting** when activating environment (`activateEnv`)
- **Added automatic interpreter setting** after syncing dependencies (`syncDependencies`)
- **Refactored interpreter logic** into separate `interpreter.js` module for better code organization
- **Added `getFirstWorkspaceFolder()` utility** to reduce code duplication

## Benefits

- Users no longer need to manually select the Python interpreter
- Editor features (linting, IntelliSense, run/debug) work immediately with the created environment
- Better code organization with interpreter logic separated from general utilities

## Testing

The implementation:
- ✅ Checks for `.venv` interpreter paths (Windows and POSIX)
- ✅ Sets workspace Python interpreter automatically
- ✅ Shows user-friendly notifications when interpreter is set
- ✅ Handles errors gracefully without blocking commands
- ✅ Works on extension activation if `.venv` already exists

Fixes #31