### PR TITLE
CI & packaging housekeeping

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      
+      - uses: actions/checkout@v5
+
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4 # Updated to latest version
-      
-      - uses: actions/setup-node@v4 # Updated to latest version
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20 # Updated to Node.js 20 LTS
+          node-version: 22
           registry-url: https://registry.npmjs.org/
 
       - name: Install the dependencies

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,6 +3,18 @@
 .github/**
 .claude/**
 test/**
+node_modules/**/test/**
+node_modules/**/tests/**
+node_modules/**/*.md
+node_modules/**/.github/**
+node_modules/**/example/**
+node_modules/**/examples/**
+node_modules/**/docs/**
+node_modules/d3-*/**
+node_modules/d3/src/**
+node_modules/internmap/**
+node_modules/delaunator/**
+node_modules/robust-predicates/**
 .gitignore
 .yarnrc
 vsc-extension-quickstart.md
@@ -10,3 +22,6 @@ vsc-extension-quickstart.md
 **/*.map
 **/.eslintrc.json
 *.vsix
+CLAUDE.md
+CHANGELOG.md
+package-lock.json


### PR DESCRIPTION
## Summary
- Bump GitHub Actions to Node.js 22 (`actions/checkout@v5`, `actions/setup-node@v5`) ahead of June 2026 deprecation
- Slim down VSIX package from 974 → ~105 files via `.vscodeignore` (exclude unused d3 subpackages, tests, docs)
- Update demo GIF: faster playback, looping, cropped trailing black frames

## Test plan
- [x] v2.0.1 published successfully with dynamic versioning
- [ ] Verify integration workflow passes with Node.js 22
- [ ] Confirm extension installs and works from the smaller VSIX

🤖 Generated with [Claude Code](https://claude.com/claude-code)